### PR TITLE
Add FuelComponent - PlayerCharacter, PlayerManager, Train, Fuel, FuelComponent, Train, CarryableActor

### DIFF
--- a/Content/Blueprints/BP_Fuel.uasset
+++ b/Content/Blueprints/BP_Fuel.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87416b11b8752a2546e5d19d8af7329a7f5b0a5630663e83e2eaf58ba8844be5
-size 30284
+oid sha256:a996f9336034ec5f0eebc7a42bb67ec6edfdabf011a77d97091ce9fe10c89bd7
+size 30416

--- a/Content/Blueprints/BP_Train.uasset
+++ b/Content/Blueprints/BP_Train.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c593964b4205de721d0f9304e87e53ed0dc7f48803c65f86311196e4142a17a
-size 31208
+oid sha256:ca68dc398efad8b6393b5885658eb9e8b1ed6fa3d12f185e8ab14d144c1470ff
+size 34634

--- a/Source/ApocTrainNetworked/Private/CarryableActor.cpp
+++ b/Source/ApocTrainNetworked/Private/CarryableActor.cpp
@@ -22,10 +22,12 @@ void ACarryableActor::OnInteract(APlayerCharacter* player)
 
 bool ACarryableActor::CurrentlyInteractable()
 {
-	if (carriedState == ECarriedState::Idle) {
-		return true;
-	}
-	return false;
+	return carriedState == ECarriedState::Idle;
+}
+
+bool ACarryableActor::IsCarried()
+{
+	return carriedState == ECarriedState::Carried;
 }
 
 void ACarryableActor::Server_OnPickedUp_Implementation(USceneComponent* carrier)
@@ -47,7 +49,7 @@ void ACarryableActor::Multi_SetRenderDepth_Implementation(bool renderdepth)
 	MeshToHighlight->SetRenderCustomDepth(renderdepth);
 }
 
-void ACarryableActor::Server_DropObject_Implementation(FVector directionToLaunch)
+void ACarryableActor::Server_DropObject_Implementation(FVector directionToLaunch, FVector dropperLocation)
 {
 	carriedState = ECarriedState::Dropped;
 	PhysicsComponent->SetSimulatePhysics(true);

--- a/Source/ApocTrainNetworked/Private/Fuel.cpp
+++ b/Source/ApocTrainNetworked/Private/Fuel.cpp
@@ -2,8 +2,57 @@
 
 
 #include "Fuel.h"
+#include "FuelComponent.h"
+#include "Components/SphereComponent.h"
+#include <Net/UnrealNetwork.h>
 
-void AFuel::OnFuelAddedToTrain()
+
+//on overlap deposit calls method deposit fuel 
+
+//player calls on dropped method on fuel, which checks if it is overlapping a component for deposit fuel
+
+//player store reference to the overlapped trigger
+
+
+
+void AFuel::Server_DropObject_Implementation(FVector directionToLaunch, FVector DropperLocation)
+{
+	Super::Server_DropObject_Implementation(directionToLaunch, DropperLocation);
+	if (LastOverlappedDeposit) {
+		if (LastOverlappedDeposit->IsInsideDeposit(DropperLocation)) {
+			LastOverlappedDeposit->Server_AddFuel(this);
+		}
+	}
+	
+}
+
+void AFuel::BeginPlay()
+{
+	Super::BeginPlay();
+	if (trigger) {
+		trigger->OnComponentBeginOverlap.AddDynamic(this, &AFuel::OnFuelBeginOverlap);
+	}
+}
+
+//do this stuff in the player, also make sure you can set render depth buffer on the deposit mesh
+
+void AFuel::OnFuelBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+	if (HasAuthority()) {
+		GEngine->AddOnScreenDebugMessage(-1, 2.0, FColor::Purple, OtherComp->GetName());
+		if (UFuelComponent* fuelComponent = OtherActor->FindComponentByClass<UFuelComponent>()) {
+			LastOverlappedDeposit = fuelComponent;
+		}
+	}
+}
+
+void AFuel::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	//DOREPLIFETIME(AFuel, LastOverlappedDeposit)
+}
+
+void AFuel::OnFuelDeposited()
 {
 
 }

--- a/Source/ApocTrainNetworked/Private/Fuel.cpp
+++ b/Source/ApocTrainNetworked/Private/Fuel.cpp
@@ -49,7 +49,6 @@ void AFuel::OnFuelBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* Othe
 void AFuel::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
-	//DOREPLIFETIME(AFuel, LastOverlappedDeposit)
 }
 
 void AFuel::OnFuelDeposited()

--- a/Source/ApocTrainNetworked/Private/FuelComponent.cpp
+++ b/Source/ApocTrainNetworked/Private/FuelComponent.cpp
@@ -1,0 +1,139 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "FuelComponent.h"
+#include "Components/BoxComponent.h"
+#include "Fuel.h"
+#include "PlayerManager.h"
+#include <Net/UnrealNetwork.h>
+#include <Kismet/KismetMathLibrary.h>
+#include "Kismet/GameplayStatics.h"
+#include "EngineUtils.h"
+
+// Sets default values for this component's properties
+UFuelComponent::UFuelComponent()
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = true;
+
+	// ...
+}
+
+
+// Called when the game starts
+void UFuelComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	SetIsReplicated(true);
+
+	for (TActorIterator<APlayerManager> IT(GetWorld()); IT; ++IT)
+	{
+		APlayerManager* foo = *IT;
+	}
+
+	for (TActorIterator<AActor> It(GetWorld(), APlayerManager::StaticClass()); It; ++It)
+	{
+		AActor* Actor = *It;
+	}
+
+	PlayerManager = Cast< APlayerManager>(UGameplayStatics::GetActorOfClass(GetWorld(), APlayerManager::StaticClass()));
+	// ...
+	DepositTrigger = GetOwner()->FindComponentByTag<UBoxComponent>("FuelDeposit");
+	MeshToHighlight = GetOwner()->FindComponentByTag<UStaticMeshComponent>("MeshToHighlight");
+
+	if (DepositTrigger) {
+		DepositTrigger->OnComponentBeginOverlap.AddDynamic(this, &UFuelComponent::OnDepositBeginOverlap);
+	}
+	
+}
+
+void UFuelComponent::OnDepositBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+	if (AFuel* fuel = Cast<AFuel>(OtherActor)) {
+		Server_AddFuel(fuel);
+	}
+}
+
+// Called every frame
+void UFuelComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+	if (!bBurning) {
+		BurnFuel(DeltaTime);
+	}
+	if (PlayerManager && DepositTrigger) {
+		if (PlayerManager->IsOverlappingPlayerWithFuel(DepositTrigger)) {
+			Server_PlayersOverlapping(true);
+		}
+		else {
+			Server_PlayersOverlapping(false);
+		}
+	}
+}
+
+bool UFuelComponent::IsInsideDeposit(FVector location)
+{
+	if (UKismetMathLibrary::IsPointInBox(location, DepositTrigger->GetComponentLocation(), DepositTrigger->GetScaledBoxExtent())) {
+		return true;
+	}
+	return false;
+}
+
+bool UFuelComponent::IsFuelCritical()
+{
+	return CurrentFuel <= CriticalLevel && HasFuel();
+}
+
+bool UFuelComponent::HasFuel()
+{
+	return CurrentFuel > 0;
+}
+
+bool UFuelComponent::IsFull()
+{
+	return CurrentFuel >= MaxFuel;
+}
+
+void UFuelComponent::OnRep_PlayerWithFuelOverlappingUpdated()
+{
+	if (MeshToHighlight) {
+		MeshToHighlight->SetRenderCustomDepth(bPlayerWithFuelOverlapping);
+	}
+}
+
+void UFuelComponent::Server_PlayersOverlapping_Implementation(bool overlapping)
+{
+	Multi_PlayersOverlapping(overlapping);
+}
+
+
+void UFuelComponent::Multi_PlayersOverlapping_Implementation(bool overlapping)
+{
+	if (MeshToHighlight) {
+		MeshToHighlight->SetRenderCustomDepth(overlapping);
+	}
+}
+
+void UFuelComponent::Server_AddFuel_Implementation(AFuel* fuel)
+{
+	if (!IsFull() && !fuel->IsCarried()) {
+		CurrentFuel += 1;
+		fuel->Destroy();
+	}
+}
+
+void UFuelComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	DOREPLIFETIME(UFuelComponent, CurrentFuel)
+}
+
+void UFuelComponent::BurnFuel(float DeltaTime)
+{
+	CurrentFuel -= BurnRate * DeltaTime;
+	if (CurrentFuel < 0) {
+		CurrentFuel = 0;
+	}
+}
+

--- a/Source/ApocTrainNetworked/Private/FuelComponent.cpp
+++ b/Source/ApocTrainNetworked/Private/FuelComponent.cpp
@@ -21,7 +21,6 @@ UFuelComponent::UFuelComponent()
 }
 
 
-// Called when the game starts
 void UFuelComponent::BeginPlay()
 {
 	Super::BeginPlay();
@@ -29,16 +28,9 @@ void UFuelComponent::BeginPlay()
 
 	for (TActorIterator<APlayerManager> IT(GetWorld()); IT; ++IT)
 	{
-		APlayerManager* foo = *IT;
+		PlayerManager = *IT;
 	}
 
-	for (TActorIterator<AActor> It(GetWorld(), APlayerManager::StaticClass()); It; ++It)
-	{
-		AActor* Actor = *It;
-	}
-
-	PlayerManager = Cast< APlayerManager>(UGameplayStatics::GetActorOfClass(GetWorld(), APlayerManager::StaticClass()));
-	// ...
 	DepositTrigger = GetOwner()->FindComponentByTag<UBoxComponent>("FuelDeposit");
 	MeshToHighlight = GetOwner()->FindComponentByTag<UStaticMeshComponent>("MeshToHighlight");
 

--- a/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
@@ -102,10 +102,10 @@ void APlayerCharacter::Server_DropCarriedItem_Implementation()
 			float upwardForce = 0.5f;
 			if (IsFacingWall()) {
 				carriedObject->SetActorLocation(GetActorLocation());
-				carriedObject->Server_DropObject((this->GetActorForwardVector() * -1) * 0.2f * throwVelocity);
+				carriedObject->Server_DropObject((this->GetActorForwardVector() * -1) * 0.2f * throwVelocity, GetActorLocation());
 			}
 			else {
-				carriedObject->Server_DropObject(((this->GetActorForwardVector()) + FVector(0, 0, upwardForce)) * throwVelocity);
+				carriedObject->Server_DropObject(((this->GetActorForwardVector()) + FVector(0, 0, upwardForce)) * throwVelocity, GetActorLocation());
 			}
 		}
 		CarryingItem = false;

--- a/Source/ApocTrainNetworked/Private/PlayerManager.cpp
+++ b/Source/ApocTrainNetworked/Private/PlayerManager.cpp
@@ -3,7 +3,9 @@
 
 #include "PlayerManager.h"
 #include "PlayerCharacter.h"
+#include "Components/BoxComponent.h"
 #include "Net/UnrealNetwork.h"
+#include <Kismet/KismetMathLibrary.h>
 
 // Sets default values
 APlayerManager::APlayerManager()
@@ -39,3 +41,26 @@ int APlayerManager::RegisterPlayerWithManager(APlayerCharacter* joinedPlayer)
 	return index;
 }
 
+bool APlayerManager::IsOverlappingPlayer(UBoxComponent* box)
+{
+	for (int i = 0; i < ActivePlayers.Num(); i++) {
+		if (UKismetMathLibrary::IsPointInBox(ActivePlayers[i]->GetActorLocation(), box->GetComponentLocation(), box->GetScaledBoxExtent()))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool APlayerManager::IsOverlappingPlayerWithFuel(UBoxComponent* box)
+{
+	for (int i = 0; i < ActivePlayers.Num(); i++) {
+		if (UKismetMathLibrary::IsPointInBox(ActivePlayers[i]->GetActorLocation(), box->GetComponentLocation(), box->GetScaledBoxExtent()))
+		{
+			if (ActivePlayers[i]->IsCarryingItem()) {
+				return true;
+			}
+		}
+	}
+	return false;
+}

--- a/Source/ApocTrainNetworked/Private/Train.cpp
+++ b/Source/ApocTrainNetworked/Private/Train.cpp
@@ -3,6 +3,8 @@
 
 #include "Train.h"
 #include "Net/UnrealNetwork.h"
+#include "FuelComponent.h"
+#include "Components/BoxComponent.h"
 
 // Sets default values
 ATrain::ATrain()
@@ -11,6 +13,7 @@ ATrain::ATrain()
 	PrimaryActorTick.bCanEverTick = true;
 	SetReplicates(true);
 	SetReplicateMovement(true);
+	FuelComponent = CreateDefaultSubobject<UFuelComponent>(TEXT("FuelComponent"));
 }
 
 void ATrain::StartTrain()
@@ -22,7 +25,6 @@ void ATrain::StartTrain()
 void ATrain::BeginPlay()
 {
 	Super::BeginPlay();
-
 }
 
 
@@ -35,6 +37,7 @@ void ATrain::Tick(float DeltaTime)
 		UpdateSpeed(DeltaTime);
 		UpdateLocation(DeltaTime);
 	}
+	UpdateFuelComponent(DeltaTime);
 }
 
 
@@ -73,9 +76,6 @@ void ATrain::UpdateSpeed(float deltaTime)
 	default:
 		break;
 	}
-	if (currentTrainState != ETrainState::stopped && currentTrainState != ETrainState::decelerating) {
-		//BurnFuel();
-	}
 }
 
 
@@ -84,6 +84,19 @@ void ATrain::UpdateLocation(float DeltaTime)
 	currentLocation = GetActorLocation();
 	currentLocation += FVector(0, 1, 0) * currentTrainSpeed * DeltaTime;
 	SetActorLocation(currentLocation, true);
+}
+
+void ATrain::UpdateFuelComponent(float DeltaTime)
+{
+	if (currentTrainState != ETrainState::stopped && currentTrainState != ETrainState::decelerating) {
+		FuelComponent->bBurning = false;
+	}
+	else {
+		FuelComponent->bBurning = true;
+	}
+	if (!FuelComponent->HasFuel()) {
+		SetTrainState(ETrainState::decelerating);
+	}
 }
 
 

--- a/Source/ApocTrainNetworked/Public/CarryableActor.h
+++ b/Source/ApocTrainNetworked/Public/CarryableActor.h
@@ -36,6 +36,7 @@ public:
 
 	virtual bool CurrentlyInteractable() override;
 
+	bool IsCarried();
 
 	UFUNCTION()
 	void OnPhysicsComponentHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit);
@@ -50,8 +51,8 @@ public:
 	void Multi_SetRenderDepth_Implementation(bool renderdepth);
 
 	UFUNCTION(Server, Unreliable)
-	void Server_DropObject(FVector directionToLaunch);
-	void Server_DropObject_Implementation(FVector directionToLaunch);
+	virtual void Server_DropObject(FVector directionToLaunch, FVector dropperLocation);
+	virtual void Server_DropObject_Implementation(FVector directionToLaunch, FVector dropperLocation);
 
 
 protected:

--- a/Source/ApocTrainNetworked/Public/Fuel.h
+++ b/Source/ApocTrainNetworked/Public/Fuel.h
@@ -13,10 +13,24 @@ UCLASS()
 class APOCTRAINNETWORKED_API AFuel : public ACarryableActor
 {
 	GENERATED_BODY()
-	
+public:
+
+
+
+	virtual void Server_DropObject_Implementation(FVector directionToLaunch, FVector DropperLocation) override;
+
+	virtual void BeginPlay() override;
+
+	UFUNCTION()
+	void OnFuelBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
 protected:
+	UPROPERTY()
+	class UFuelComponent* LastOverlappedDeposit;
 
 	UFUNCTION(BlueprintCallable)
-	void OnFuelAddedToTrain();
+	void OnFuelDeposited();
 };

--- a/Source/ApocTrainNetworked/Public/FuelComponent.h
+++ b/Source/ApocTrainNetworked/Public/FuelComponent.h
@@ -1,0 +1,82 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "FuelComponent.generated.h"
+
+
+
+UENUM()
+enum class EFuelState : uint8 {
+	normal UMETA(DIsplayName = "Normal"), critical UMETA(DIsplayName = "Critical")
+};
+
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class APOCTRAINNETWORKED_API UFuelComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	// Sets default values for this component's properties
+	UFuelComponent();
+
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+
+public:	
+
+	UFUNCTION()
+	void OnDepositBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+	// Called every frame
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	bool bBurning;
+
+	UPROPERTY(Replicated,EditDefaultsOnly, BlueprintReadWrite)
+	float CurrentFuel;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	float MaxFuel;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	float CriticalLevel;
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly)
+	float BurnRate;
+
+	bool IsInsideDeposit(FVector location);
+
+	bool IsFuelCritical();
+	bool HasFuel();
+
+	UFUNCTION(Server, Unreliable)
+	void Server_AddFuel(class AFuel* fuel);
+	void Server_AddFuel_Implementation(class AFuel* fuel);
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+protected:
+
+	void BurnFuel(float DeltaTime);
+	bool IsFull();
+	class UBoxComponent* DepositTrigger;
+	class UStaticMeshComponent* MeshToHighlight;
+	class APlayerManager* PlayerManager;
+
+	UPROPERTY(ReplicatedUsing=OnRep_PlayerWithFuelOverlappingUpdated)
+	bool bPlayerWithFuelOverlapping;
+
+	UFUNCTION()
+	void OnRep_PlayerWithFuelOverlappingUpdated();
+
+	UFUNCTION(Server, Unreliable)
+	void Server_PlayersOverlapping(bool overlapping);
+	virtual void Server_PlayersOverlapping_Implementation(bool overlapping);
+
+	UFUNCTION(NetMulticast, Unreliable)
+	void Multi_PlayersOverlapping(bool overlapping);
+	virtual void Multi_PlayersOverlapping_Implementation(bool overlapping);
+
+};

--- a/Source/ApocTrainNetworked/Public/PlayerManager.h
+++ b/Source/ApocTrainNetworked/Public/PlayerManager.h
@@ -35,4 +35,8 @@ public:
 
 	int RegisterPlayerWithManager(class APlayerCharacter* joinedPlayer);
 
+	bool IsOverlappingPlayer(class UBoxComponent* box);
+
+	bool IsOverlappingPlayerWithFuel(class UBoxComponent* box);
+
 };

--- a/Source/ApocTrainNetworked/Public/Train.h
+++ b/Source/ApocTrainNetworked/Public/Train.h
@@ -12,11 +12,6 @@ enum class ETrainState : uint8 {
 	stopped UMETA(DIsplayName = "Stopped"), accelerating UMETA(DIsplayName = "Accelerating"), decelerating UMETA(DIsplayName = "Decelerating")
 };
 
-UENUM()
-enum class EFuelState : uint8 {
-	normal UMETA(DIsplayName = "Normal"), critical UMETA(DIsplayName = "Critical")
-};
-
 
 UCLASS()
 class APOCTRAINNETWORKED_API ATrain : public AActor
@@ -26,10 +21,8 @@ class APOCTRAINNETWORKED_API ATrain : public AActor
 public:	
 
 	ATrain();
-	void UpdateSpeed(float deltaTime);
 	FVector GetTrainLocation();
 	bool IsTrainStopped();
-
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 
@@ -55,7 +48,9 @@ protected:
 	virtual void Tick(float DeltaTime) override;
 
 	bool IsGameOverCountingDown();
+	void UpdateSpeed(float deltaTime);
 	void UpdateLocation(float DeltaTime);
+	void UpdateFuelComponent(float DeltaTime);
 	UFUNCTION()
 	void SetTrainState(ETrainState stateToSet);
 	UFUNCTION(BlueprintCallable)
@@ -65,5 +60,7 @@ protected:
 	UFUNCTION(BlueprintImplementableEvent)
 	void NotifyTrainStop();
 
+	UPROPERTY(EditDefaultsOnly)
+	class UFuelComponent* FuelComponent;
 
 };


### PR DESCRIPTION

TODO: 
Allow players to add fuel to train or other objects and have fuel affect properties of the object. 

Solution:
Create a FuelComponent that can be created in c++ and handles adding burning and destroying fuel on its own. Can have multiple deposit triggers. Fuel also checks if it is inside a deposit trigger when dropped for quick access.

Extras:
BUGFIX - possibly fixed fuel being far away from player when picked up. Set mesh and trigger component to replicate.