### PR TITLE
Add player action state

### DIFF
--- a/Source/ApocTrainNetworked/Public/PlayerCharacter.h
+++ b/Source/ApocTrainNetworked/Public/PlayerCharacter.h
@@ -15,6 +15,13 @@ enum class EPlayerMovementState : uint8
 	standing UMETA(DisplayName = "Standing"), walking UMETA(DisplayName = "Walking"), dashing UMETA(DisplayName = "Dashing")
 };
 
+UENUM()
+enum class EPlayerActionState : uint8
+{
+	idle UMETA(DisplayName = "Idle"), attacking UMETA(DisplayName = "Attacking"), carrying UMETA(DisplayName = "Carrying")
+};
+
+
 UCLASS()
 class APOCTRAINNETWORKED_API APlayerCharacter : public ACharacter
 {
@@ -64,8 +71,12 @@ protected:
 	void SetPlayerMovementState(EPlayerMovementState NewMovementState);
 
 	//INTERACT MECHANICS
-	UPROPERTY(BlueprintReadOnly)
-	bool CarryingItem;
+	EPlayerActionState CurrentActionState;
+
+	void SetPlayerActionState(EPlayerActionState NewActionState);
+
+	//UPROPERTY(BlueprintReadOnly)
+	//bool bCarryingItem;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly)
 	float throwVelocity;
@@ -125,6 +136,7 @@ public:
 	virtual void SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent) override;
 
 	bool IsCarryingItem();
+	bool IsAttacking();
 	bool IsFacingWall();
 
 	UFUNCTION(Server, Unreliable)


### PR DESCRIPTION
TODO: stop player shooting while carrying

Solution:
introduce player action state enum to handle switching states and keep state logic semi-independentant from eachother