### PR TITLE
Add networking to flash comp and obstacle destroy vfx

### DIFF
--- a/Content/Blueprints/Obstacles/BP_BasicObstacle.uasset
+++ b/Content/Blueprints/Obstacles/BP_BasicObstacle.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a45acb751bf250ee14397a954fec27b8699e80e3fd1de22f0aeca2b9785f4388
-size 30538
+oid sha256:ae6c52c76937514aa3013cd63a792b0ebf9390472348af754352247b50f3b1b3
+size 58902

--- a/Source/ApocTrainNetworked/Private/ChunkSpawner.cpp
+++ b/Source/ApocTrainNetworked/Private/ChunkSpawner.cpp
@@ -26,7 +26,6 @@ void AChunkSpawner::SpawnNewChunk()
 	int chunkIndex = FMath::RandRange(0,LevelChunks.Num()-1);
 	ALevelChunk* chunk = Cast<ALevelChunk>(GetWorld()->SpawnActor(LevelChunks[chunkIndex],new FVector(0, targetPostion, -40), new FRotator(), FActorSpawnParameters()));
 	targetPostion += chunk->GetChunkLength();
-	GEngine->AddOnScreenDebugMessage(-1, 30, FColor::Blue, FString::Printf(TEXT("new target position: %f"), targetPostion));
 }
 
 bool AChunkSpawner::TargetReached()

--- a/Source/ApocTrainNetworked/Private/LevelChunk.cpp
+++ b/Source/ApocTrainNetworked/Private/LevelChunk.cpp
@@ -23,7 +23,6 @@ void ALevelChunk::BeginPlay()
 			UStaticMeshComponent* mesh = Cast<UStaticMeshComponent>(Component);
 			if (mesh && mesh->ComponentHasTag("ChunkBase")) {
 				chunkLength = (mesh->GetStaticMesh()->GetBounds().BoxExtent.Y * 2) * mesh->GetComponentScale().Y;
-				GEngine->AddOnScreenDebugMessage(-1, 20, FColor::Magenta, FString::Printf(TEXT("CHUNK LENGTH: %d"), mesh->GetComponentScale().Y));
 			}
 		}
 	}

--- a/Source/ApocTrainNetworked/Private/Obstacle.cpp
+++ b/Source/ApocTrainNetworked/Private/Obstacle.cpp
@@ -5,6 +5,7 @@
 #include "PulseComponent.h"
 #include "FlashComponent.h"
 #include <Kismet/GameplayStatics.h>
+#include "Particles/ParticleSystemComponent.h"
 
 // Sets default values
 AObstacle::AObstacle()
@@ -21,7 +22,22 @@ void AObstacle::BeginPlay()
 {
 	Super::BeginPlay();
 	SetReplicates(true);
+	bAlwaysRelevant = true;
 	currentHealth = MaxHealth;
+}
+
+void AObstacle::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	Super::EndPlay(EndPlayReason);
+
+	switch (EndPlayReason)
+	{
+		case EEndPlayReason::Destroyed:
+			if (DestroyedDust) {
+				UGameplayStatics::SpawnEmitterAtLocation(GetWorld(), DestroyedDust, GetActorLocation(), GetActorRotation())->SetIsReplicated(true);
+			}
+			break;
+	}
 }
 
 // Called every frame
@@ -41,10 +57,7 @@ void AObstacle::Damage(float damageToTake)
 		flashComponent->Flash();
 	}
 	if (currentHealth <= 0) {
-		if (DestroyedDust) {
-			UGameplayStatics::SpawnEmitterAtLocation(GetWorld(), DestroyedDust, GetActorLocation(), GetActorRotation());
-		}
-		Destroy(0);
+		Destroy();
 	}
 }
 

--- a/Source/ApocTrainNetworked/Public/FlashComponent.h
+++ b/Source/ApocTrainNetworked/Public/FlashComponent.h
@@ -7,6 +7,7 @@
 #include "FlashComponent.generated.h"
 
 
+
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
 class APOCTRAINNETWORKED_API UFlashComponent : public UActorComponent
 {
@@ -23,18 +24,26 @@ protected:
 
 	void GetMaterialsToFlash();
 
+	UPROPERTY(Replicated)
 	TArray<UMaterialInstanceDynamic*> FlashMaterials;
 	
 	UPROPERTY(EditDefaultsOnly)
-	FLinearColor colorToFlash;
+	FLinearColor ColorToFlash;
+
+	UPROPERTY(ReplicatedUsing = OnRep_MaterialColor)
+	FLinearColor MaterialColor;
+
+	UFUNCTION()
+	void OnRep_MaterialColor();
 
 	UPROPERTY(EditDefaultsOnly)
 	float FlashDuration;
 
 	FTimerHandle flashTimerHandle;
 
-	UFUNCTION()
 	void ResetFlashColor();
+
+	void SetMaterialParameter(FLinearColor NewParameter);
 
 public:
 	// Called every frame
@@ -42,4 +51,6 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	void Flash();
+
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
 };

--- a/Source/ApocTrainNetworked/Public/Obstacle.h
+++ b/Source/ApocTrainNetworked/Public/Obstacle.h
@@ -25,6 +25,8 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
 	float currentHealth;
 
 	UPROPERTY(EditDefaultsOnly)


### PR DESCRIPTION
TODO:
implement networking with flash component and the destroy vfx

Solution:
needed to use a Repnotify for the flash material 

ran into an issue where destroying the actor after rpc would cause the rpc not to fire due to network time, so used endplay to spawn the vfx instead