### PR TITLE
PFE add crosshair aiming

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -44,8 +44,8 @@ AppliedDefaultGraphicsPerformance=Maximum
 
 [/Script/Engine.RendererSettings]
 r.GenerateMeshDistanceFields=True
-r.DynamicGlobalIlluminationMethod=1
-r.ReflectionMethod=1
+r.DynamicGlobalIlluminationMethod=0
+r.ReflectionMethod=0
 r.Shadow.Virtual.Enable=1
 r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
 r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8

--- a/Content/Blueprints/Core/PC_ATPlayerController.uasset
+++ b/Content/Blueprints/Core/PC_ATPlayerController.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d24aa33b63972fd4dad454c432c473005dc8a4e0e6aa7b94d0a92cb348ae9a82
-size 40105
+oid sha256:fbe801a1d4a0bc8a64866f46fefbf1b195d2fde38ba99c92c9d4691cdb1bf14d
+size 39785

--- a/Source/ApocTrainNetworked/ApocTrainNetworked.Build.cs
+++ b/Source/ApocTrainNetworked/ApocTrainNetworked.Build.cs
@@ -17,8 +17,10 @@ public class ApocTrainNetworked : ModuleRules
 			"Niagara",
 			"AIModule",
 			"GameplayTasks",
-			"NavigationSystem"
-		});
+			"NavigationSystem",
+            "Slate",        // using to detect if gamepad is connected
+			"SlateCore"		// using to detect if gamepad is connected
+        });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/Source/ApocTrainNetworked/Private/EnemyCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/EnemyCharacter.cpp
@@ -51,6 +51,7 @@ void AEnemyCharacter::InitializeEnemy()
 	bIsDead = true;
 	bCanAttack = true;
 	CurrentState = EEnemyState::idle;
+	OnDespawn();
 }
 
 // Called every frame
@@ -114,7 +115,6 @@ void AEnemyCharacter::OnDespawn()
 
 	GetCharacterMovement()->GravityScale = 0;
 	SetActorLocation(FVector(-10000,-10000,-10000));
-	
 }
 
 bool AEnemyCharacter::CanSpawn()

--- a/Source/ApocTrainNetworked/Private/EnemySpawnManager.cpp
+++ b/Source/ApocTrainNetworked/Private/EnemySpawnManager.cpp
@@ -32,7 +32,7 @@ void AEnemySpawnManager::SpawnEnemiesOnChunk(float Ypos)
 	if (HasAuthority()) {
 		for (AObjectPooler* p : EnemyPools) {
 			for (int i = 0; i < EnemiesPerChunk; i++) {
-				p->SpawnObject(FVector(i * 50, Ypos, 0));
+				p->SpawnObject(FVector(i * 50, Ypos, 40));
 			}
 		}
 	}

--- a/Source/ApocTrainNetworked/Private/FlashComponent.cpp
+++ b/Source/ApocTrainNetworked/Private/FlashComponent.cpp
@@ -42,6 +42,10 @@ void UFlashComponent::GetMaterialsToFlash()
 
 void UFlashComponent::OnRep_MaterialColor()
 {
+	//should probobly loop all
+	if (FlashMaterials[0] == NULL) {
+		return;
+	}
 	for (UMaterialInstanceDynamic* mat : FlashMaterials) {
 		mat->SetVectorParameterValue(FName("FlashVector"), MaterialColor);
 	}

--- a/Source/ApocTrainNetworked/Private/ObjectPooler.cpp
+++ b/Source/ApocTrainNetworked/Private/ObjectPooler.cpp
@@ -16,6 +16,7 @@ AObjectPooler::AObjectPooler()
 void AObjectPooler::BeginPlay()
 {
 	Super::BeginPlay();
+	//InitialPos = FVector(-10000, -10000, -10000);
 	CreateObjects();
 }
 
@@ -25,7 +26,7 @@ void AObjectPooler::CreateObjects()
 		for (int i = 0; i < TotalObjects; i++) {
 			FActorSpawnParameters SpawnParams;
 			SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-			AActor* obj = GetWorld()->SpawnActor(ObjectType, new FVector(InitialPos.X, InitialPos.Y, InitialPos.Z), new FRotator(), SpawnParams);
+			AActor* obj = GetWorld()->SpawnActor(ObjectType, new FVector(InitialPos.X, InitialPos.Y * (i*50), InitialPos.Z), new FRotator(), SpawnParams);
 			if (IPoolable* pooledObject = Cast<IPoolable>(obj)) {
 				Pool.Enqueue(pooledObject);
 			}

--- a/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
@@ -63,7 +63,7 @@ void APlayerCharacter::Tick(float DeltaTime)
 	//if a gamepad is not connected, make sure to rotate controller towards the mouse position
 	if (!IsGamepadConnected()) {
 		//get cursor in world space
-		FVector HitLocation = GetHitResultUnderCursorExample();
+		FVector HitLocation = GetHitResultUnderCursor();
 		//rotate character
 		RotateCharacterToLookAt(HitLocation);
 	}
@@ -229,7 +229,7 @@ void APlayerCharacter::DoLook(const FInputActionValue& Value)
 		Controller->SetControlRotation(NewRotation);
 	}
 	else {
-		FVector HitLocation = GetHitResultUnderCursorExample();
+		FVector HitLocation = GetHitResultUnderCursor();
 		RotateCharacterToLookAt(HitLocation);
 	}
 }
@@ -255,7 +255,7 @@ void APlayerCharacter::RotateCharacterToLookAt( FVector TargetPosition)
 	}
 }
 
-FVector APlayerCharacter::GetHitResultUnderCursorExample()
+FVector APlayerCharacter::GetHitResultUnderCursor()
 {
 	if (Controller)
 	{

--- a/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/PlayerCharacter.cpp
@@ -11,6 +11,8 @@
 #include "Components/SphereComponent.h"
 #include "Perception/AIPerceptionStimuliSourceComponent.h"
 #include "Perception/AISenseConfig_Sight.h"
+#include "InputCoreTypes.h"
+#include <Kismet/GameplayStatics.h>
 
 // Sets default values
 APlayerCharacter::APlayerCharacter()
@@ -57,7 +59,14 @@ void APlayerCharacter::Tick(float DeltaTime)
 {
 	
 	Super::Tick(DeltaTime);
-	//GEngine->AddOnScreenDebugMessage(-1, 0.1f, FColor::Green, FString::Printf(TEXT("Switched to: %d"), CurrentState));
+	
+	//if a gamepad is not connected, make sure to rotate controller towards the mouse position
+	if (!IsGamepadConnected()) {
+		//get cursor in world space
+		FVector HitLocation = GetHitResultUnderCursorExample();
+		//rotate character
+		RotateCharacterToLookAt(HitLocation);
+	}
 
 	float CurrentSpeed = GetVelocity().Size();
 	if (CurrentSpeed > GetCharacterMovement()->MaxWalkSpeed)
@@ -98,7 +107,7 @@ void APlayerCharacter::SetupPlayerInputComponent(UInputComponent* PlayerInputCom
 	if (UEnhancedInputComponent* Input = CastChecked<UEnhancedInputComponent>(PlayerInputComponent))
 	{
 		Input->BindAction(MoveAction, ETriggerEvent::Triggered, this, &APlayerCharacter::DoMove);
-		Input->BindAction(LookAction, ETriggerEvent::Triggered, this, &APlayerCharacter::DoLook);
+		//Input->BindAction(LookAction, ETriggerEvent::Triggered, this, &APlayerCharacter::DoLook);
 
 		Input->BindAction(DashAction, ETriggerEvent::Started, this, &APlayerCharacter::DoDash);
 		Input->BindAction(AttackAction, ETriggerEvent::Started, this, &APlayerCharacter::StartAttack);
@@ -209,15 +218,65 @@ void APlayerCharacter::DoMove(const FInputActionValue& Value)
 
 void APlayerCharacter::DoLook(const FInputActionValue& Value)
 {
-	const FVector2D value = Value.Get<FVector2D>();
-	if (Controller)
+	FVector2D value = Value.Get<FVector2D>();
+	
+	//if there is a gamepad connected, use gamepad rotation
+	if (IsGamepadConnected() && Controller)
 	{
 		FVector RotVector = FVector(-value.Y, value.X, 0);
 		FRotator RotDir = UKismetMathLibrary::MakeRotFromX(RotVector);
 		FRotator NewRotation = FMath::Lerp(GetControlRotation(), RotDir, 0.2f);
 		Controller->SetControlRotation(NewRotation);
 	}
+	else {
+		FVector HitLocation = GetHitResultUnderCursorExample();
+		RotateCharacterToLookAt(HitLocation);
+	}
 }
+
+void APlayerCharacter::RotateCharacterToLookAt( FVector TargetPosition)
+{
+	// Get the current character location
+	FVector CharacterLocation = GetActorLocation();
+
+	TargetPosition = FVector(TargetPosition.X, TargetPosition.Y, CharacterLocation.Z);
+	// Calculate the direction to the target position 
+	FVector Direction = TargetPosition - CharacterLocation;
+
+	if (!Direction.IsNearlyZero())
+	{
+		// Get the target rotation from the direction vector
+		FRotator TargetRotation = Direction.Rotation();
+
+		// Smoothly interpolate the rotation for smoother turning
+		FRotator NewRotation = FMath::RInterpTo(GetActorRotation(), TargetRotation, GetWorld()->GetDeltaSeconds(), 10.0f);
+
+		Controller->SetControlRotation(FRotator(0.0f, NewRotation.Yaw, 0.0f));
+	}
+}
+
+FVector APlayerCharacter::GetHitResultUnderCursorExample()
+{
+	if (Controller)
+	{
+		FHitResult HitResult;
+		if (Cast<APlayerController>(Controller)->GetHitResultUnderCursor(ECC_Visibility, true, HitResult))
+		{
+			return HitResult.Location;
+		}
+	}
+	return FVector(0,0,0);
+}
+
+bool APlayerCharacter::IsGamepadConnected()
+{
+	if (FSlateApplication::IsInitialized())
+	{
+		return FSlateApplication::Get().IsGamepadAttached();
+	}
+	return false;
+}
+
 
 void APlayerCharacter::DoDash(const FInputActionValue& Value)
 {

--- a/Source/ApocTrainNetworked/Public/PlayerCharacter.h
+++ b/Source/ApocTrainNetworked/Public/PlayerCharacter.h
@@ -132,6 +132,13 @@ protected:
 
 	void InteractReleased(const FInputActionValue& Value);
 
+	bool IsGamepadConnected();
+
+	FVector GetLookLocationAtFixedZ(float FixedZ);
+
+	FVector GetHitResultUnderCursorExample();
+	void RotateCharacterToLookAt(const FVector TargetPosition);
+
 	UFUNCTION()
 	void OnOverlapBegin(class UPrimitiveComponent* OverlappedComponent, class AActor* OtherActor, class UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult & SweepResult);
 


### PR DESCRIPTION
TODO: if no controller connected, player should face mouse cursor

Solution: if gamepad is not connected, update the characters rotation on tick to point towards the xy cords of the mouse cursor in world position