### PR TITLE
BUG-3-milestone-1

### DIFF
--- a/Content/Blueprints/UI/BP_NumberPopup.uasset
+++ b/Content/Blueprints/UI/BP_NumberPopup.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06a5d5c4a6cc89a98869c54b341d42bcb28398943a831aafa3ec3b45ee5af65b
-size 62867
+oid sha256:a03100e56d27f0debca8bf6b388c3fbe697c9d7f8b42b4379bbff74fec5ac500
+size 62650

--- a/Content/Blueprints/Weapons/WeaponData/DA_Sniper.uasset
+++ b/Content/Blueprints/Weapons/WeaponData/DA_Sniper.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30217016b67416a7f386d8aa04388a88ff9b0ffa317fe9051633b231713fcb62
+oid sha256:67a9291ab6a4d82920ed8a2854a5fc57f0a94ec12c9eb07ae93b37fe6135bb3f
 size 1730

--- a/Content/Maps/TrainTesting.umap
+++ b/Content/Maps/TrainTesting.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13fa01f9bc24d9e2b34c74347623679ae909c65b52814e11aea70c583256b93f
-size 100704
+oid sha256:c6586cdf32de2042e9b21f3bef80512274ba0f63c076c4ae4e83a549eafd8916
+size 100770

--- a/Content/UI/Widgets/WorldSpace/WB_DamageIndicator2.uasset
+++ b/Content/UI/Widgets/WorldSpace/WB_DamageIndicator2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76b070507be7ef467a171d9cb01a611678942c9bbb9402b642f2eb2b2bc7fa0f
-size 290386
+oid sha256:f14aa2ec3efe463210f652874b05d6cb107c8d9a31bba011f845b2328a4e0358
+size 343141

--- a/Source/ApocTrainNetworked/Private/Core/PlayerCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/Core/PlayerCharacter.cpp
@@ -101,6 +101,9 @@ void APlayerCharacter::Tick(float DeltaTime)
 	}
 	//GEngine->AddOnScreenDebugMessage(-1, 5, FColor::Red, FString::Printf(TEXT("FacingWall: %d"), IsFacingWall()));
 
+	FString EnumValueAsString = UEnum::GetValueAsString(CurrentActionState);
+	GEngine->AddOnScreenDebugMessage(-1, 1, FColor::Green, EnumValueAsString); 
+
 	float CurrentSpeed = GetVelocity().Size();
 	if (CurrentSpeed > GetCharacterMovement()->MaxWalkSpeed)
 	{
@@ -228,10 +231,16 @@ void APlayerCharacter::Server_PickupItem_Implementation(ACarryableActor* itemToC
 	if (IsCarryingItem()) {
 		return;
 	}
-	SetPlayerActionState(EPlayerActionState::carrying);
-	carriedObject = itemToCarry;
 	itemToCarry->Server_OnPickedUp(characterMesh);
+	Multi_PickupItem(itemToCarry);
 	
+}
+
+void APlayerCharacter::Multi_PickupItem_Implementation(ACarryableActor* itemToCarry)
+{
+	SetPlayerActionState(EPlayerActionState::carrying);
+	EquippedWeapon->StopAttack();
+	carriedObject = itemToCarry;
 }
 
 
@@ -419,6 +428,7 @@ void APlayerCharacter::StopAction(const FInputActionValue& Value)
 void APlayerCharacter::StopAttacking()
 {
 	if (IsAttacking()) {
+
 		EquippedWeapon->StopAttack();
 		if (!IsCarryingItem()) {
 			SetPlayerActionState(EPlayerActionState::idle);

--- a/Source/ApocTrainNetworked/Private/Core/PlayerCharacter.cpp
+++ b/Source/ApocTrainNetworked/Private/Core/PlayerCharacter.cpp
@@ -101,8 +101,8 @@ void APlayerCharacter::Tick(float DeltaTime)
 	}
 	//GEngine->AddOnScreenDebugMessage(-1, 5, FColor::Red, FString::Printf(TEXT("FacingWall: %d"), IsFacingWall()));
 
-	FString EnumValueAsString = UEnum::GetValueAsString(CurrentActionState);
-	GEngine->AddOnScreenDebugMessage(-1, 1, FColor::Green, EnumValueAsString); 
+	//FString EnumValueAsString = UEnum::GetValueAsString(CurrentActionState);
+	//GEngine->AddOnScreenDebugMessage(-1, 1, FColor::Green, EnumValueAsString); 
 
 	float CurrentSpeed = GetVelocity().Size();
 	if (CurrentSpeed > GetCharacterMovement()->MaxWalkSpeed)

--- a/Source/ApocTrainNetworked/Private/Weapons/ProjectileWeapon.cpp
+++ b/Source/ApocTrainNetworked/Private/Weapons/ProjectileWeapon.cpp
@@ -9,6 +9,7 @@ AProjectileWeapon::AProjectileWeapon()
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
+	bIsHolding = false;
 }
 
 void AProjectileWeapon::BeginPlay()
@@ -26,6 +27,7 @@ void AProjectileWeapon::Tick(float DeltaTime)
 
 void AProjectileWeapon::StartAttack()
 {
+	bIsHolding = true;
 	if (CurrentWeaponState != EProjectileWeaponState::shooting)
 	{
 		SetWeaponState(EProjectileWeaponState::shooting);
@@ -37,6 +39,7 @@ void AProjectileWeapon::StartAttack()
 void AProjectileWeapon::StopAttack()
 {
 	GetWorldTimerManager().ClearTimer(AttackRateTimerHandle);
+	bIsHolding = false;
 }
 
 void AProjectileWeapon::Attack()
@@ -73,6 +76,7 @@ void AProjectileWeapon::Attack()
 				}
 			}
 		}
+		OnAttack.Broadcast();
 		Multicast_AttackEffects();
 	}
 }
@@ -83,12 +87,16 @@ void AProjectileWeapon::Multicast_AttackEffects_Implementation()
 	{
 		UNiagaraFunctionLibrary::SpawnSystemAtLocation(GetWorld(), Data->BulletTracer, GetAttachParentActor()->GetActorLocation() + GetAttachParentActor()->GetActorRightVector() * 20.0f, GetAttachParentActor()->GetActorForwardVector().Rotation());
 	}
-	OnAttack.Broadcast();
 }
 
 void AProjectileWeapon::ResetAttack()
 {
 	SetWeaponState(EProjectileWeaponState::idle);
+	if (bIsHolding == true)
+	{
+		StartAttack();
+	}
+
 }
 
 void AProjectileWeapon::Reload()

--- a/Source/ApocTrainNetworked/Private/Weapons/ProjectileWeapon.cpp
+++ b/Source/ApocTrainNetworked/Private/Weapons/ProjectileWeapon.cpp
@@ -27,6 +27,7 @@ void AProjectileWeapon::Tick(float DeltaTime)
 
 void AProjectileWeapon::StartAttack()
 {
+	//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, FString::Printf(TEXT("STARTED ATTACKING")));
 	bIsHolding = true;
 	if (CurrentWeaponState != EProjectileWeaponState::shooting)
 	{
@@ -40,6 +41,7 @@ void AProjectileWeapon::StopAttack()
 {
 	GetWorldTimerManager().ClearTimer(AttackRateTimerHandle);
 	bIsHolding = false;
+	//GEngine->AddOnScreenDebugMessage(-1, 5.f, FColor::Red, FString::Printf(TEXT("STOPPED ATTACKING")));
 }
 
 void AProjectileWeapon::Attack()

--- a/Source/ApocTrainNetworked/Public/Core/PlayerCharacter.h
+++ b/Source/ApocTrainNetworked/Public/Core/PlayerCharacter.h
@@ -230,6 +230,9 @@ public:
 	UFUNCTION(Server, Unreliable)
 	void Server_PickupItem(class ACarryableActor* itemToCarry);
 
+	UFUNCTION(NetMulticast, Unreliable)
+	void Multi_PickupItem(ACarryableActor* itemToCarry);
+
 	UFUNCTION(Server, Reliable)
 	void Server_OnInteract(bool interacting);
 

--- a/Source/ApocTrainNetworked/Public/Weapons/ProjectileWeapon.h
+++ b/Source/ApocTrainNetworked/Public/Weapons/ProjectileWeapon.h
@@ -31,6 +31,8 @@ protected:
 
 	EProjectileWeaponState CurrentWeaponState;
 
+	bool bIsHolding;
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Weapon)
 	float ReloadTime;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Weapon)


### PR DESCRIPTION
- if already shooting and pick up fuel, player keeps shooting infinity without pressing anything. only on clients.
- insta re-holding shoot will not buffer the shot input, so no shooting will happen.
- damage number pop ups don't show 3rd number.