### PR TITLE
check for fuel deposit on hit,

### DIFF
--- a/Source/ApocTrainNetworked/Private/Entities/Fuel.cpp
+++ b/Source/ApocTrainNetworked/Private/Entities/Fuel.cpp
@@ -15,26 +15,17 @@
 
 
 
+void AFuel::OnPhysicsComponentHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit)
+{
+	Super::OnPhysicsComponentHit(HitComp, OtherActor, OtherComp, NormalImpulse, Hit);
+	CheckForDeposit();
+}
+
 void AFuel::Server_DropObject_Implementation(FVector directionToLaunch, FVector DropperLocation)
 {
 	//this is bad - if player has not entered fuel box with fuel yet this will not work bc last overlap deposit is null need to find a new method
 	Super::Server_DropObject_Implementation(directionToLaunch, DropperLocation);
-	TArray<AActor*> OverlappingActors;
-	GetOverlappingActors(OverlappingActors);
-
-	for (AActor* Actor : OverlappingActors)
-	{
-		if (Actor) {
-			if (UFuelComponent* fuelComp = Actor->FindComponentByClass<UFuelComponent>())
-			{
-				if(fuelComp->IsInsideDeposit(GetActorLocation()))
-				{
-					fuelComp->Server_AddFuel(this);
-					GEngine->AddOnScreenDebugMessage(-1, 1, FColor::Red, TEXT("ADDFUEL"));
-				}
-			}
-		}
-	}
+	CheckForDeposit();
 }
 
 void AFuel::BeginPlay()
@@ -60,4 +51,24 @@ void AFuel::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimePro
 void AFuel::OnFuelDeposited()
 {
 
+}
+
+void AFuel::CheckForDeposit()
+{
+	TArray<AActor*> OverlappingActors;
+	GetOverlappingActors(OverlappingActors);
+
+	for (AActor* Actor : OverlappingActors)
+	{
+		if (Actor) {
+			if (UFuelComponent* fuelComp = Actor->FindComponentByClass<UFuelComponent>())
+			{
+				if (fuelComp->IsInsideDeposit(GetActorLocation()))
+				{
+					fuelComp->Server_AddFuel(this);
+					GEngine->AddOnScreenDebugMessage(-1, 1, FColor::Red, TEXT("ADDFUEL"));
+				}
+			}
+		}
+	}
 }

--- a/Source/ApocTrainNetworked/Public/Entities/CarryableActor.h
+++ b/Source/ApocTrainNetworked/Public/Entities/CarryableActor.h
@@ -41,7 +41,7 @@ public:
 	bool IsCarried();
 
 	UFUNCTION()
-	void OnPhysicsComponentHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit);
+	virtual void OnPhysicsComponentHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit);
 
 
 	UFUNCTION(Server, Unreliable)

--- a/Source/ApocTrainNetworked/Public/Entities/Fuel.h
+++ b/Source/ApocTrainNetworked/Public/Entities/Fuel.h
@@ -15,7 +15,7 @@ class APOCTRAINNETWORKED_API AFuel : public ACarryableActor
 	GENERATED_BODY()
 public:
 
-
+	virtual void OnPhysicsComponentHit(UPrimitiveComponent* HitComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, FVector NormalImpulse, const FHitResult& Hit) override; 
 
 	virtual void Server_DropObject_Implementation(FVector directionToLaunch, FVector DropperLocation) override;
 
@@ -31,4 +31,6 @@ protected:
 
 	UFUNCTION(BlueprintCallable)
 	void OnFuelDeposited();
+
+	void CheckForDeposit();
 };


### PR DESCRIPTION
TODO:
FIx fuel not depositing

Solutions:
 add second barrier (a deposit check on hit) to make sure fuel doesnt miss deposit box